### PR TITLE
Leave time for minions to appear in the preview list

### DIFF
--- a/features/salt_ssh.feature
+++ b/features/salt_ssh.feature
@@ -48,8 +48,9 @@ Feature: 1) Bootstrap a new salt host via salt-ssh
     And I should see a "Remote Commands" text
     Then I enter command "rpm -q salt-minion"
     And I click on preview
+    And I wait for "3" seconds
     And I click on run
-    Then I wait for "3" seconds
+    And I wait for "3" seconds
     And I expand the results for "ssh-minion"
     Then I should see a "package salt-minion is not installed" text
 
@@ -123,8 +124,9 @@ Feature: 1) Bootstrap a new salt host via salt-ssh
     And I should see a "Remote Commands" text
     Then I enter command "rpm -q salt-minion"
     And I click on preview
+    And I wait for "3" seconds
     And I click on run
-    Then I wait for "3" seconds
+    And I wait for "3" seconds
     And I expand the results for "ssh-minion"
     Then I should see a "package salt-minion is not installed" text
 


### PR DESCRIPTION
We randomly get random errors in the test suite for 3.0, in scenario "Run a remote command on ssh-minion". One of the minions is not appearing in the list.

This PR will hopefully leave it enough time to appear.